### PR TITLE
Implement SQLite task store

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Todo_list/
 - **Frontend**: React.js
 - **Backend**: Go (Golang)
 - **API**: RESTful API
-- **Database**: In-memory storage (can be extended to use a database)
+ - **Database**: SQLite
 
 ## Features
 
@@ -61,6 +61,10 @@ npm install
 cd ../backend
 go mod tidy
 ```
+4. Create the SQLite database:
+```bash
+sqlite3 tasks.db < migrations/001_create_tasks.sql
+```
 
 ### Running the Application
 
@@ -70,6 +74,7 @@ cd backend
 go run main.go
 ```
 The backend will run on `http://localhost:8080`
+You can set the `DB_PATH` environment variable to specify a custom SQLite file.
 
 2. Start the frontend development server:
 ```bash

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module example.com/todolist/backend
 go 1.17
 
 require (
+github.com/mattn/go-sqlite3 v1.14.15
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/cors v1.11.1
 )

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,109 +1,112 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
+	"log"
 	"net/http"
+	"os"
 	"strconv"
-	"sync"
-	"time"
 
 	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/cors"
 )
 
-type Task struct {
-	ID        int    `json:"id"`
-	Text      string `json:"text"`
-	Completed bool   `json:"completed"`
-	Status    string `json:"status"`
-	StartDate string `json:"startDate"`
-	EndDate   string `json:"endDate"`
-}
-
-var (
-	tasks  = make(map[int]Task)
-	nextID = 1
-	mutex  = &sync.Mutex{}
-)
+var store *TaskStore
 
 func getTasks(w http.ResponseWriter, r *http.Request) {
-	mutex.Lock()
-	defer mutex.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	var taskList []Task
-	for _, task := range tasks {
-		taskList = append(taskList, task)
+	tasks, err := store.GetAll()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
-	json.NewEncoder(w).Encode(taskList)
+	json.NewEncoder(w).Encode(tasks)
 }
 
 func createTask(w http.ResponseWriter, r *http.Request) {
-	mutex.Lock()
-	defer mutex.Unlock()
 	var task Task
 	if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	task.ID = nextID
-	nextID++
 	if task.Status == "" {
 		task.Status = "todo"
 	}
-	tasks[task.ID] = task
+	if err := store.Create(&task); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(task)
 }
 
 func updateTask(w http.ResponseWriter, r *http.Request) {
-	mutex.Lock()
-	defer mutex.Unlock()
 	params := mux.Vars(r)
 	id, err := strconv.Atoi(params["id"])
 	if err != nil {
 		http.Error(w, "Invalid task ID", http.StatusBadRequest)
 		return
 	}
-
-	if _, ok := tasks[id]; !ok {
+	if _, err := store.GetByID(id); err != nil {
 		http.NotFound(w, r)
 		return
 	}
-
 	var updatedTask Task
 	if err := json.NewDecoder(r.Body).Decode(&updatedTask); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
+	if err := store.Update(id, updatedTask); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	updatedTask.ID = id
-	tasks[id] = updatedTask
-
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(updatedTask)
 }
 
 func deleteTask(w http.ResponseWriter, r *http.Request) {
-	mutex.Lock()
-	defer mutex.Unlock()
 	params := mux.Vars(r)
 	id, err := strconv.Atoi(params["id"])
 	if err != nil {
 		http.Error(w, "Invalid task ID", http.StatusBadRequest)
 		return
 	}
-
-	if _, ok := tasks[id]; !ok {
+	if err := store.Delete(id); err != nil {
 		http.NotFound(w, r)
 		return
 	}
-
-	delete(tasks, id)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func main() {
+	dbPath := os.Getenv("DB_PATH")
+	if dbPath == "" {
+		dbPath = "./tasks.db"
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS tasks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        text TEXT NOT NULL,
+        completed BOOLEAN NOT NULL DEFAULT 0,
+        status TEXT,
+        start_date TEXT,
+        end_date TEXT
+    )`); err != nil {
+		log.Fatal(err)
+	}
+
+	store = NewTaskStore(db)
+
 	r := mux.NewRouter()
 
 	r.HandleFunc("/tasks", getTasks).Methods("GET")
@@ -118,11 +121,6 @@ func main() {
 	})
 
 	handler := c.Handler(r)
-
-	// Pre-populate with some data
-	tasks[1] = Task{ID: 1, Text: "Learn Go", Status: "todo", StartDate: time.Now().Format("2006-01-02"), EndDate: ""}
-	tasks[2] = Task{ID: 2, Text: "Learn React", Status: "done", StartDate: time.Now().Format("2006-01-02"), EndDate: time.Now().Format("2006-01-02")}
-	nextID = 3
 
 	http.ListenAndServe(":8080", handler)
 }

--- a/backend/migrations/001_create_tasks.sql
+++ b/backend/migrations/001_create_tasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text TEXT NOT NULL,
+    completed BOOLEAN NOT NULL DEFAULT 0,
+    status TEXT,
+    start_date TEXT,
+    end_date TEXT
+);

--- a/backend/store.go
+++ b/backend/store.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"database/sql"
+)
+
+// TaskStore provides database operations for tasks.
+type TaskStore struct {
+	db *sql.DB
+}
+
+// NewTaskStore creates a store with the given database handle.
+func NewTaskStore(db *sql.DB) *TaskStore {
+	return &TaskStore{db: db}
+}
+
+// GetAll returns all tasks from the database.
+func (s *TaskStore) GetAll() ([]Task, error) {
+	rows, err := s.db.Query(`SELECT id, text, completed, status, start_date, end_date FROM tasks`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tasks []Task
+	for rows.Next() {
+		var t Task
+		if err := rows.Scan(&t.ID, &t.Text, &t.Completed, &t.Status, &t.StartDate, &t.EndDate); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+// Create inserts a new task into the database.
+func (s *TaskStore) Create(t *Task) error {
+	res, err := s.db.Exec(`INSERT INTO tasks (text, completed, status, start_date, end_date) VALUES (?, ?, ?, ?, ?)`,
+		t.Text, t.Completed, t.Status, t.StartDate, t.EndDate)
+	if err != nil {
+		return err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return err
+	}
+	t.ID = int(id)
+	return nil
+}
+
+// Update modifies an existing task.
+func (s *TaskStore) Update(id int, t Task) error {
+	_, err := s.db.Exec(`UPDATE tasks SET text = ?, completed = ?, status = ?, start_date = ?, end_date = ? WHERE id = ?`,
+		t.Text, t.Completed, t.Status, t.StartDate, t.EndDate, id)
+	return err
+}
+
+// Delete removes a task from the database.
+func (s *TaskStore) Delete(id int) error {
+	_, err := s.db.Exec(`DELETE FROM tasks WHERE id = ?`, id)
+	return err
+}
+
+// GetByID retrieves a task by id.
+func (s *TaskStore) GetByID(id int) (Task, error) {
+	var t Task
+	err := s.db.QueryRow(`SELECT id, text, completed, status, start_date, end_date FROM tasks WHERE id = ?`, id).
+		Scan(&t.ID, &t.Text, &t.Completed, &t.Status, &t.StartDate, &t.EndDate)
+	return t, err
+}

--- a/backend/task.go
+++ b/backend/task.go
@@ -1,0 +1,11 @@
+package main
+
+// Task represents a to-do item.
+type Task struct {
+	ID        int    `json:"id"`
+	Text      string `json:"text"`
+	Completed bool   `json:"completed"`
+	Status    string `json:"status"`
+	StartDate string `json:"startDate"`
+	EndDate   string `json:"endDate"`
+}


### PR DESCRIPTION
## Summary
- add SQLite database setup and TaskStore implementation
- update REST handlers to use the store
- provide initial migration script
- document new database setup in README

## Testing
- `gofmt -w backend/*.go`
- `go mod tidy` *(fails: proxy access blocked)*
- `go build ./...` *(fails: proxy access blocked)*
- `go test ./...` *(fails: proxy access blocked)*
- `npm test --prefix frontend` *(fails: react-scripts missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a71e6d4888328b981a41ce7fd01b7