### PR TITLE
Wrap new-task inputs in form and add fetch POST test

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -269,7 +269,7 @@ function App() {
             </div>
           )}
           
-          <div className="bg-white rounded-lg shadow-sm p-6">
+          <form className="bg-white rounded-lg shadow-sm p-6" onSubmit={addTask}>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div className="md:col-span-2">
                 <input
@@ -307,7 +307,7 @@ function App() {
                 Agregar Tarea
               </button>
             </div>
-          </div>
+          </form>
         </header>
         
         <main className="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,44 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeEach(() => {
+  global.fetch = jest.fn((url, options) => {
+    if (options?.method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 1,
+          text: 'Comprar leche',
+          startDate: '2026-06-09',
+          endDate: '',
+          status: 'todo',
+        }),
+      });
+    }
+
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('creates a new task with a POST request', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  const input = await screen.findByPlaceholderText('Nueva tarea...');
+  await userEvent.type(input, 'Comprar leche');
+  await userEvent.click(screen.getByRole('button', { name: /agregar tarea/i }));
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/tasks',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
 });


### PR DESCRIPTION
### Motivation
- Make the "Agregar Tarea" button reliably trigger the `addTask` handler via a form submit so the creation flow runs consistently and `e.preventDefault()` remains effective.

### Description
- Wrap the new task input block in a `<form onSubmit={addTask}>` and keep the button as `type="submit"` to wire submission to `addTask` (file `frontend/src/App.js`).
- Preserve `e.preventDefault()` inside `addTask` so the default page navigation is prevented when submitting the form.
- Replace the placeholder React test with a new test in `frontend/src/App.test.js` that mocks `fetch`, renders `App`, types into the input with placeholder `Nueva tarea...`, clicks the "Agregar Tarea" button, and asserts `fetch` was called with a `POST` request to the tasks endpoint.
- Changed files: `frontend/src/App.js`, `frontend/src/App.test.js`.

### Testing
- Ran `npm test -- --watchAll=false --runInBand` from `frontend/`, and the test suite passed including the new test `creates a new task with a POST request`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288004b3008328a9b43ffda83bf873)